### PR TITLE
test:migrate to latest pytest-invenio and docker-services-cli

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,6 @@
 # details.
 
 [pytest]
-pep8ignore = docs/conf.py ALL
-addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=invenio_theme_tugraz --cov-report=term-missing
-testpaths = docs tests invenio_theme_tugraz
-filterwarnings = ignore::pytest.PytestDeprecationWarning 
+addopts = --isort --pydocstyle --pycodestyle --doctest-glob="*.rst" --doctest-modules --cov=invenio_theme_tugraz --cov-report=term-missing
+testpaths = tests invenio_theme_tugraz
+live_server_scope = module

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,8 +7,11 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-pydocstyle invenio_theme_tugraz tests docs && \
-isort invenio_theme_tugraz tests --check-only --diff && \
-check-manifest --ignore ".travis-*" && \
-sphinx-build -qnNW docs docs/_build/html && \
-pytest
+docker-services-cli up postgresql es redis
+python -m check_manifest --ignore ".travis-*" && \
+python -m sphinx.cmd.build -qnNW docs docs/_build/html && \
+docker-services-cli up es postgresql redis
+python -m pytest
+tests_exit_code=$?
+docker-services-cli down
+exit "$tests_exit_code"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'pytest-invenio>=1.3.2',
+    'pytest-invenio>=1.4.0',
 ]
 
 extras_require = {


### PR DESCRIPTION
* modified the testes to run from new ```invenio-pytest``` module.
this closes #96.